### PR TITLE
使用系统默认下载目录，并优化下载重试处理

### DIFF
--- a/Editer.py
+++ b/Editer.py
@@ -23,6 +23,7 @@ class Editer(object):
     def __init__(self, root_path, book_no='0000', volume_no=1):
         self.url_head = 'https://www.wenku8.net' 
         self.header = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.67 Safari/537.36 Edg/87.0.664.47', 'referer': self.url_head}
+        self.session = requests.Session()
 
         self.main_page = f'{self.url_head}/book/{book_no}.htm'
         self.color_chap_name = '插图'
@@ -39,7 +40,7 @@ class Editer(object):
     
             
         self.img_url_map = dict()
-        self.volume_no = volume_no
+        self.volume_no = int(volume_no)
 
         self.epub_path = root_path
         self.temp_path = (os.path.join(self.epub_path,  'temp_'+ check_chars(self.title) + '_' + str(self.volume_no)))
@@ -56,15 +57,17 @@ class Editer(object):
     def get_html(self, url, is_gbk=False):
         time.sleep(1)
         while True:
-            req = requests.get(url, headers=self.header)
-            if is_gbk:
-                req.encoding = 'GBK'       #这里是网页的编码转换，根据网页的实际需要进行修改，经测试这个编码没有问题
-            if '<title>Access denied | www.wenku8.net used Cloudflare to restrict access</title>' in req.text:
+            try:
+                req = self.session.get(url, headers=self.header, timeout=20)
+                if is_gbk:
+                    req.encoding = 'GBK'       #这里是网页的编码转换，根据网页的实际需要进行修改，经测试这个编码没有问题
+                if req.status_code == 429 or 'Access denied' in req.text:
+                    time.sleep(3)
+                    continue
+                req.raise_for_status()
+                return req.text
+            except requests.RequestException:
                 time.sleep(3)
-            else:
-                break
-        req = req.text
-        return req
     
     def get_html_img(self, url, is_buffer=False):
         if is_buffer:
@@ -74,10 +77,11 @@ class Editer(object):
             return self.html_buffer[url]
         while True:
             try:
-                req=requests.get(url, headers=self.header)
+                req = self.session.get(url, headers=self.header, timeout=20)
+                req.raise_for_status()
                 break
-            except Exception as e:
-                pass
+            except requests.RequestException:
+                time.sleep(1)
         lock.acquire()
         self.html_buffer[url] = req.content
         lock.release()
@@ -134,25 +138,42 @@ class Editer(object):
     
     def get_chap_text(self, url, chap_name, is_color=False):
         print(chap_name)
-        content_html = self.get_html(url, is_gbk=True)
-        bf = BeautifulSoup(content_html, 'html.parser')
-        text_with_head = bf.find('div', {'id': 'content'}) 
-        text_chap = ''
-        if is_color:
-            img_url_htmls = text_with_head.find_all('img', {'class': 'imagecontent'})
-            img_urls = [img_url_html.get('src') for img_url_html in img_url_htmls]
-            for img_url in img_urls:
-                self.img_url_map[img_url] = str(len(self.img_url_map)).zfill(2)
-                img_symbol = f'[img:{self.img_url_map[img_url]}]'
-                if '00' not in img_symbol:
-                    text_chap += (img_symbol+'\n')
-        else:
+        for _ in range(3):
+            content_html = self.get_html(url, is_gbk=True)
+            bf = BeautifulSoup(content_html, 'html.parser')
+            text_with_head = bf.find('div', {'id': 'content'})
+            text_chap = ''
+
+            if is_color:
+                if text_with_head is not None:
+                    img_url_htmls = text_with_head.find_all('img', {'class': 'imagecontent'})
+                else:
+                    img_url_htmls = bf.find_all('img', {'class': 'imagecontent'})
+
+                if len(img_url_htmls) == 0:
+                    time.sleep(1)
+                    continue
+
+                img_urls = [img_url_html.get('src') for img_url_html in img_url_htmls if img_url_html.get('src')]
+                for img_url in img_urls:
+                    self.img_url_map[img_url] = str(len(self.img_url_map)).zfill(2)
+                    img_symbol = f'[img:{self.img_url_map[img_url]}]'
+                    if '00' not in img_symbol:
+                        text_chap += (img_symbol+'\n')
+                return text_chap
+
+            if text_with_head is None:
+                time.sleep(1)
+                continue
+
             text_html = str(text_with_head)
             for line in text_html.split('\n'):
                 if not line.startswith('<ul id="contentdp">') and not line.startswith('<br/>'):
                     text_chap += (line+'\n')
             text_chap = BeautifulSoup(text_chap, 'html.parser').get_text()
-        return text_chap
+            return text_chap
+
+        raise ValueError(f'章节内容解析失败：{chap_name} ({url})')
     
     def get_text(self):
         self.make_folder()   

--- a/lightnovel.py
+++ b/lightnovel.py
@@ -8,7 +8,7 @@ def parse_args():
     """Parse input arguments."""
     parser = argparse.ArgumentParser(description='config')
     parser.add_argument('--book_no', default='0000', type=str)
-    parser.add_argument('--volume_no', default='1', type=int)
+    parser.add_argument('--volume_no', default='1', type=str)
     parser.add_argument('--no_input', default=False, type=bool)
     args = parser.parse_args()
     return args

--- a/lightnovel_gui.py
+++ b/lightnovel_gui.py
@@ -1,5 +1,5 @@
 # coding:utf-8
-from PyQt5.QtCore import Qt, pyqtSignal, QObject, QThread, QRegExp
+from PyQt5.QtCore import Qt, pyqtSignal, QObject, QThread, QRegExp, QStandardPaths
 from PyQt5.QtGui import QIcon, QFont, QTextCursor, QPixmap, QColor,QRegExpValidator
 from PyQt5.QtWidgets import QApplication, QFrame, QGridLayout, QFileDialog
 from qfluentwidgets import (setTheme, Theme, PushSettingCard, SettingCardGroup, ExpandLayout, TextEdit, ImageLabel, LineEdit, PushButton, Theme, ProgressRing, setTheme, Theme, OptionsSettingCard, OptionsConfigItem, OptionsValidator, FluentWindow, SubtitleLabel, NavigationItemPosition, setThemeColor, qconfig, EditableComboBox, BoolValidator)
@@ -13,6 +13,13 @@ from lightnovel import *
 
 font_label = QFont('微软雅黑', 18)
 font_msg = QFont('微软雅黑', 11)
+
+
+def get_default_download_path():
+    download_path = QStandardPaths.writableLocation(QStandardPaths.DownloadLocation)
+    if download_path:
+        return download_path
+    return os.path.expanduser('~')
 
 class MainThread(QThread):
     def __init__(self, parent):
@@ -282,7 +289,7 @@ class Window(FluentWindow):
     def __init__(self):
         super().__init__()
 
-        self.out_path = os.path.join(os.path.expanduser('~'), 'Downloads')
+        self.out_path = get_default_download_path()
         self.head = 'https://www.wenku8.net'
         split_str = '**************************************\n    '
         self.welcome_text = f'使用说明（共4条，记得下拉）：\n{split_str}1.轻小说文库{self.head}，根据书籍网址输入书号以及下载的卷号，书号最多输入4位阿拉伯数字。\n{split_str}2.例如小说网址是{self.head}/book/3138.htm，则书号输入3138。\n{split_str}3.要查询书籍卷号卷名等信息，则可以只输入书号不输入卷号，点击确定会返回书籍卷名称和对应的卷号。\n{split_str}4.根据上一步返回的信息确定自己想下载的卷号，要下载编号[2]对应卷，则卷号输入2。想下载多卷比如[1]至[3]对应卷，则卷号输入1-3或1,2,3（英文逗号分隔，编号也可以不连续）并点击确定。'


### PR DESCRIPTION
这个 PR 包含两个修复：

1. GUI 默认下载目录改为使用系统提供的下载目录，而不是手动拼接 ~/Downloads，这样在 Windows 等环境下会更可靠，避免默认下载路径不一致的问题。

2. 修复命令行模式下的卷号解析问题，并增强章节下载时的重试处理。现在 volume_no 的处理更一致；当网站临时返回 429、访问受限页面或章节内容异常时(AttributeError: 'NoneType' object has no attribute 'find_all')，下载器会更稳妥地重试，而不是直接报错。